### PR TITLE
Corrige o erro durante o split em linhas que tem `;` no campo. #16

### DIFF
--- a/code/EleicoesTransparentesPersistance/src/br/ufba/eleicoestransparentes/model/database/Comunicacao.java
+++ b/code/EleicoesTransparentesPersistance/src/br/ufba/eleicoestransparentes/model/database/Comunicacao.java
@@ -244,6 +244,10 @@ public class Comunicacao {
 
 		AgenteEleitoral agente = insereAgenteEleitoral(new AgenteEleitoral());
 		cand.setAgenteEleitoral(agente);
+		
+		if(cand.getPartido() != null && cand.getPartido().getId() <= 0){
+			cand.setPartido(inserePartido(cand.getPartido()));
+		}
 
 		return comiteDAO.createIfNotExists(cand);
 	}

--- a/code/ParserTSE/src/br/ufba/eleicoestransparentes/business/parser/ParserFile.java
+++ b/code/ParserTSE/src/br/ufba/eleicoestransparentes/business/parser/ParserFile.java
@@ -23,7 +23,7 @@ public abstract class ParserFile <T, M> {
 	public void parsing(OnReadDataListener<M> dataListener) throws IOException{
 		BufferedReader br = null;
 		String line = "";
-		String cvsSplitBy = ";";
+		String cvsSplitBy = "§";
 		
 		int totalLines = FileUtil.countLines(csvFile);
 		int indexLine = 0;
@@ -36,6 +36,8 @@ public abstract class ParserFile <T, M> {
 				indexLine++;
 				continue;
 			}
+			line = line.replace("§", " ");
+			line = line.replace("\";\"", "\"§\"");
 			line = line.replace("\"\"", " ");
 			line = line.replace("\"", " ");
 			line = line.replace("#NULO#", " ");

--- a/code/ParserTSE/src/br/ufba/eleicoestransparentes/business/parser/ano2012/ParserPrestacaoContasComiteReceita2012.java
+++ b/code/ParserTSE/src/br/ufba/eleicoestransparentes/business/parser/ano2012/ParserPrestacaoContasComiteReceita2012.java
@@ -74,7 +74,7 @@ public class ParserPrestacaoContasComiteReceita2012 extends ParserFile<PrestCont
 		trans.setValor(Float.parseFloat(pccr.getValorReceita().replace(",", ".")));
 		trans.setClassificacao(pccr.getTipoReceita());
 		trans.setDescricao(pccr.getDescricaoReceita());
-		trans.setCreditado(createComite(pccr)); //TODO Comite não é uma pessoa
+		trans.setCreditado(createComite(pccr)); 
 		trans.setDebitado(createDoador(pccr));
 		trans.setTipo(Transacao.RECEITA);
 		trans.setUF(pccr.getUF());


### PR DESCRIPTION
Devido a possibilidade de conter `;` dentro de um campo, antes do
parser, todos os `§` são substituídos por ` ` e todos `";"` são substítuidos por `"§"`,
e então o split é realizados usando o símbolo `§`, evitando assim um
split errado.